### PR TITLE
Fix 回答目录项作者显示有误

### DIFF
--- a/src/modules/Answer.js
+++ b/src/modules/Answer.js
@@ -94,7 +94,7 @@ function Answer(iZhihu) {
                     $author.insertBefore($meta);
                 }
             }
-            $author=$author.children().first().children().eq(1);
+            $author=$author.children().eq(1);
             if ($pp && bAuthorList){
                 // Region: 回答目录项
                 var collapsed=$a.attr('data-collapsed')=='1'


### PR DESCRIPTION
Fix 回答目录项作者显示有误：作者栏均显示匿名用户。
因知乎改版引起的bug。